### PR TITLE
fixed the signup modal for and id to have proper names

### DIFF
--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -53,18 +53,18 @@
                 </div>
                 <div class="modal-body">
                     <div>
-                        <label for="login-username">Username</label>
-                        <div><input id="login-username" name="username" /></div>
+                        <label for="signup-username">Username</label>
+                        <div><input id="signup-username" name="username" /></div>
                     </div>
                     <br>
                     <div>
-                        <label for="login-email">Email</label>
-                        <div><input id="login-email" name="email" /></div>
+                        <label for="signup-email">Email</label>
+                        <div><input id="signup-email" name="email" /></div>
                     </div>
                     <br>
                     <div>
-                        <label for="login-password">Password</label>
-                        <div><input id="login-password" name="login-password" /></div>
+                        <label for="signup-password">Password</label>
+                        <div><input id="signup-password" name="signup-password" /></div>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
Changed the attributes names in the signup modal HTML. They should now be "signup-" instead of "login-"